### PR TITLE
ChainFilter invoked for all types on createDateParser

### DIFF
--- a/src/json.date-extensions.js
+++ b/src/json.date-extensions.js
@@ -46,24 +46,23 @@
         /// <returns type="Function">returns a new chainning filter for dates</returns>
         function createDateParser(chainFilter) {
             return function(key, value) {
+                var parsedValue = value;
                 if (typeof value === 'string') {
                     var a = reISO.exec(value);
-                    if (a)
-                        return new Date(value);
-
-                    if (!JSON.parseMsAjaxDate)
-                        return value;
-
-                    a = reMsAjax.exec(value);
                     if (a) {
-                        var b = a[1].split(/[-+,.]/);
-                        return new Date(b[0] ? +b[0] : 0 - +b[1]);
+                        parsedValue = new Date(value);
+                    } else if (JSON.parseMsAjaxDate) {
+                        a = reMsAjax.exec(value);
+                        if (a) {
+                            var b = a[1].split(/[-+,.]/);
+                            parsedValue = new Date(b[0] ? +b[0] : 0 - +b[1]);
+                        }
                     }
                 }
                 if (chainFilter !== undefined)
-                    return chainFilter(key, value);
+                    return chainFilter(key, parsedValue);
                 else
-                    return value;
+                    return parsedValue;
             };
         }
 


### PR DESCRIPTION
Currently, chainFilter is only called for non-string values. I think it would be better to invoke the chainFilter for all parsed values, including dates.
