### PR TITLE
fix function declaration on strict mode

### DIFF
--- a/src/json.date-extensions.js
+++ b/src/json.date-extensions.js
@@ -44,7 +44,7 @@
         /// </summary>    
         /// <param name="chainFilter" type="Function">property name that is parsed</param>
         /// <returns type="Function">returns a new chainning filter for dates</returns>
-        function createDateParser(chainFilter) {
+        var createDateParser = function(chainFilter) {
             return function(key, value) {
                 var parsedValue = value;
                 if (typeof value === 'string') {


### PR DESCRIPTION
When `json.date-extensions.js` is concatenated in [strict mode](http://www.w3schools.com/js/js_strict.asp), the following error was occurring:

```
Uncaught SyntaxError: In strict mode code, functions can only be declared at top level or immediately within another function.
```

This patch fixes it.